### PR TITLE
Remove the rewrite of UNL_Templates::$options['version'] "3.1" -> "3x1" ...

### DIFF
--- a/src/UNL/Templates.php
+++ b/src/UNL/Templates.php
@@ -91,9 +91,9 @@ class UNL_Templates extends UNL_DWT
      */
     public static function loadDefaultConfig()
     {
-        self::$options['version'] = str_replace('.', 'x', self::$options['version']);
-        include_once 'UNL/Templates/Version'.self::$options['version'].'.php';
-        $class = 'UNL_Templates_Version'.self::$options['version'];
+        $version = str_replace('.', 'x', self::$options['version']);
+        include_once 'UNL/Templates/Version'.$version.'.php';
+        $class = 'UNL_Templates_Version'.$version;
         self::$template_version = new $class();
         UNL_DWT::$options = array_merge(UNL_DWT::$options, self::$template_version->getConfig());
     }


### PR DESCRIPTION
...in UNL_Templates::loadDefaultConfig() so that comparisons such as

(UNL_Templates::$options['version'] == UNL_Templates::VERSION3x1) still work.
