### PR TITLE
Added new param for site's URL

### DIFF
--- a/src/Auth/AuthCAS.php
+++ b/src/Auth/AuthCAS.php
@@ -3,12 +3,12 @@ namespace UNL\Templates\Auth;
 
 class AuthCAS implements AuthInterface
 {
-  public function __construct($version, $hostname, $port, $uri, $cert = NULL, $sessionName = NULL) {
+  public function __construct($version, $hostname, $port, $uri, $siteURL, $cert = NULL, $sessionName = NULL) {
     if (!\phpCAS::isInitialized()) {
       if (!empty($sessionName)) {
         session_name($sessionName);
       }
-      \phpCAS::client($version, $hostname, $port, $uri);
+      \phpCAS::client($version, $hostname, $port, $uri, $siteURL);
       if (!empty($cert)) {
         \phpCAS::setCasServerCACert($cert);
       } else {


### PR DESCRIPTION
With the update of phpCAS to 1.6.0 they added a new parameter to their client function called $service_base_url. This just kinda boils down to adding the site URL to function call. 

[phpCAS Update](https://github.com/apereo/phpCAS/commit/b759361d904a2cb2a3bcee9411fc348cfde5d163)